### PR TITLE
Fix hlpr tests after datetime tool addition

### DIFF
--- a/tests/test_hlpr.py
+++ b/tests/test_hlpr.py
@@ -3,11 +3,26 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 import argparse
 import builtins
 import sys
+import datetime
+import tempfile
+import subprocess
+import os
+import contextlib
 from types import SimpleNamespace
 
 import pytest
 
-from hlpr import read_file, parse_args, repl_run, print_stats
+from hlpr import (
+    read_file,
+    parse_args,
+    repl_run,
+    print_stats,
+    get_current_datetime_utc,
+    get_current_datetime_utc_tool,
+    handle_edit_command,
+    responses_create,
+)
+import hlpr
 
 
 class DummyUsage:
@@ -18,8 +33,16 @@ class DummyUsage:
         self.total_tokens = 3
 
 
+class DummyOutput:
+    def __init__(self, type="message", name=None, call_id="1"):
+        self.type = type
+        self.name = name
+        self.call_id = call_id
+
+
 class DummyResponse:
     def __init__(self, text="dummy"):
+        self.output = [DummyOutput("message")]
         self.output_text = text
         self.usage = DummyUsage()
 
@@ -116,3 +139,75 @@ def test_repl_run_with_web(monkeypatch):
     assert len(tools) == 2
     assert tools[1]["type"] == "web_search_preview"
     assert tools[1]["search_context_size"] == "low"
+
+
+def test_get_current_datetime_utc(monkeypatch):
+    fixed = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    monkeypatch.setattr(hlpr, "datetime", SimpleNamespace(now=lambda tz=None: fixed))
+    result = get_current_datetime_utc()
+    assert "2024-01-01 12:00:00+00:00" in result
+
+
+def test_get_current_datetime_utc_tool():
+    tool = get_current_datetime_utc_tool()
+    assert tool["type"] == "function"
+    assert tool["name"] == "get_current_datetime_utc"
+    assert tool["parameters"]["type"] == "object"
+
+
+def test_handle_edit_command(monkeypatch):
+    def fake_run(cmd, check):
+        with open(cmd[1], "w", encoding="utf-8") as f:
+            f.write("edited")
+
+    tmp_paths = []
+    original = tempfile.NamedTemporaryFile
+
+    def fake_tmp(*args, **kwargs):
+        tmp = original(*args, **kwargs)
+        tmp_paths.append(tmp.name)
+        return tmp
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", fake_tmp)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = handle_edit_command()
+    assert result == "edited"
+    assert not os.path.exists(tmp_paths[0])
+
+
+def test_responses_create_function_call(monkeypatch):
+    class SeqClient:
+        def __init__(self, responses):
+            self._responses = responses
+            self.responses = SimpleNamespace(create=self._create)
+            self.calls = []
+
+        def _create(self, model=None, input=None, tools=None):
+            self.calls.append((model, input, tools))
+            return self._responses.pop(0)
+
+    # First response triggers the function call
+    func_call = DummyOutput("function_call", name="get_current_datetime_utc", call_id="1")
+    r1 = DummyResponse()
+    r1.output = [func_call]
+    r1.output_text = ""
+
+    # Second response returns the assistant message
+    r2 = DummyResponse("done")
+
+    client = SeqClient([r1, r2])
+
+    monkeypatch.setattr(hlpr, "Spinner", lambda msg: contextlib.nullcontext())
+    monkeypatch.setattr(hlpr, "get_current_datetime_utc", lambda: "utc")
+
+    messages = [{"role": "user", "content": "hi"}]
+    create_args = {"model": "gpt-4o-mini", "input": messages, "tools": [get_current_datetime_utc_tool()]}
+
+    text = responses_create(client, create_args, messages)
+
+    assert text == "done"
+    # Function call output should have been appended
+    assert isinstance(messages[1], DummyOutput)
+    assert messages[1].type == "function_call"
+    assert messages[2]["type"] == "function_call_output"


### PR DESCRIPTION
## Summary
- update test helpers for new API shape
- add coverage for datetime tool, edit command, and tool call handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684385946964832e9cb10db8bfeec685